### PR TITLE
switch to Gripe.TestAssurancePack.XUnit

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -34,29 +34,9 @@
     <Packable Condition="$(IsTestProject) != 'true' and $(MSBuildProjectName.StartsWith('Vetuviem.'))">false</Packable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(IsTestProject)">
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <EnableStaticNativeInstrumentation>False</EnableStaticNativeInstrumentation>
-    <EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
-  </PropertyGroup>
-
   <ItemGroup Condition="$(IsTestProject)">
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
-    <PackageReference Include="Microsoft.Testing.Platform" Version="2.3.0" />
-    <PackageReference Include="NetTestRegimentation" Version="2.0.8" />
-    <PackageReference Include="NetTestRegimentation.Xunit" Version="2.0.8" />
+    <PackageReference Include="Gripe.TestAssurancePack.XUnit" Version="2.0.116" />
     <PackageReference Include="Rocks" Version="10.3.0" PrivateAssets="all" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.27.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
-    <!--<PackageReference Include="PublicApiGenerator" Version="8.1.0" />-->
-    <!--<Compile Include="$(MSBuildThisFileDirectory)ApiGeneratorGlobalSuppressions.cs" />-->
   </ItemGroup>
 
   <ItemGroup Condition="$(IsTestProject)">

--- a/src/Vetuviem.IntegrationTests/Vetuviem.IntegrationTests.csproj
+++ b/src/Vetuviem.IntegrationTests/Vetuviem.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.19041</TargetFramework>
+    <OutputType>exe</OutputType>
     <UseWpf>True</UseWpf>
     <Nullable>enable</Nullable>
     <NoWarn>CA1034,CA1515</NoWarn>

--- a/src/Vetuviem.UnitTests/Vetuviem.UnitTests.csproj
+++ b/src/Vetuviem.UnitTests/Vetuviem.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>exe</OutputType>
     <Nullable>enable</Nullable>
     <NoWarn>CA1034,CA1515</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Removed unused testing properties and package references.